### PR TITLE
upgrade v4.1.0-rc2

### DIFF
--- a/.github/scripts/versions.sh
+++ b/.github/scripts/versions.sh
@@ -6,6 +6,7 @@ mkdir -p .versions
 rm -rf .versions/versions.txt
 for file in $(pwd)/.github/versions/${part}/CHANGELOG*
 do
+  wget -qO "$file" "https://github.com/kubernetes/kubernetes/raw/master/CHANGELOG/${file##*/}"
   versions=$(echo $file | cut -d '-' -f 3 | cut -d '.' -f 1,2)
   cat $file| grep "\[v"| grep -v "github"  | grep -v "alpha" | grep -v "stable"| grep -v "there" | grep -v "beta"| grep -v "rc" | awk '{print $2}' | cut -d '[' -f  2 | cut -d ']' -f 1 | cut -d 'v' -f 2  |  awk '{printf "{\"'version'\":\"%s\"},",$1}' >> .versions/versions.txt
 done

--- a/.github/scripts/versions_arch.sh
+++ b/.github/scripts/versions_arch.sh
@@ -6,6 +6,7 @@ mkdir -p .versions
 rm -rf .versions/versions_arch.txt
 for file in $(pwd)/.github/versions/${part}/CHANGELOG*
 do
+  wget -qO "$file" "https://github.com/kubernetes/kubernetes/raw/master/CHANGELOG/${file##*/}"
   versions=$(echo $file | cut -d '-' -f 3 | cut -d '.' -f 1,2)
   cat $file| grep "\[v"| grep -v "github"  | grep -v "alpha" | grep -v "stable"| grep -v "there" | grep -v "beta"| grep -v "rc" | awk '{print $2}' | cut -d '[' -f  2 | cut -d ']' -f 1 | cut -d 'v' -f 2  |  awk '{printf "{\"'version'\":\"%s\",\"'arch'\":\"amd64\"},{\"'version'\":\"%s\",\"'arch'\":\"arm64\"},",$1,$1}' >> .versions/versions_arch.txt
 done

--- a/.github/workflows/autobuild-apps-schedule.yml
+++ b/.github/workflows/autobuild-apps-schedule.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
 
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
@@ -79,8 +77,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-apps-schedule.yml
+++ b/.github/workflows/autobuild-apps-schedule.yml
@@ -6,7 +6,7 @@ on:
 #  schedule:
 #    - cron: '0 22 * * *'
 env:
-  sealos: 4.1.0-rc1
+  sealos: 4.1.0-rc2
 jobs:
   resolve-versions-arch:
     runs-on: ubuntu-latest

--- a/.github/workflows/autobuild-apps.yml
+++ b/.github/workflows/autobuild-apps.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Build Image
@@ -72,8 +70,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-apps.yml
+++ b/.github/workflows/autobuild-apps.yml
@@ -4,7 +4,7 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
+  sealos: 4.1.0-rc2
 
 jobs:
   resolve-issue-var:

--- a/.github/workflows/autobuild-configs.yml
+++ b/.github/workflows/autobuild-configs.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Write vars

--- a/.github/workflows/autobuild-configs.yml
+++ b/.github/workflows/autobuild-configs.yml
@@ -4,7 +4,7 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
+  sealos: 4.1.0-rc2
 jobs:
   issue_comment:
     name: Auto build config image

--- a/.github/workflows/autobuild-dockerfiles.yml
+++ b/.github/workflows/autobuild-dockerfiles.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Build Image
@@ -72,8 +70,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-dockerfiles.yml
+++ b/.github/workflows/autobuild-dockerfiles.yml
@@ -4,7 +4,7 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
+  sealos: 4.1.0-rc2
 
 jobs:
   resolve-issue-var:

--- a/.github/workflows/autobuild-hosted.yml
+++ b/.github/workflows/autobuild-hosted.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Build Image
@@ -72,8 +70,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-hosted.yml
+++ b/.github/workflows/autobuild-hosted.yml
@@ -4,7 +4,7 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
+  sealos: 4.1.0-rc2
 jobs:
   resolve-issue-var:
     if: startswith(github.event.comment.body, '/imagebuild_hosted')

--- a/.github/workflows/autobuild-k8s-docker-part1.yml
+++ b/.github/workflows/autobuild-k8s-docker-part1.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
 
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
@@ -90,8 +88,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-k8s-docker-part1.yml
+++ b/.github/workflows/autobuild-k8s-docker-part1.yml
@@ -5,7 +5,7 @@ on:
       - created
 env:
   sealos: 4.1.0-rc2
-  dockerVersion: 20.10.9
+  dockerVersion: 20.10.17
   part: docker1
   criType: docker
 jobs:

--- a/.github/workflows/autobuild-k8s-part1.yml
+++ b/.github/workflows/autobuild-k8s-part1.yml
@@ -4,9 +4,9 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
-  containerdVersion: 1.6.2
-  nerdctlVersion: 0.16.0
+  sealos: 4.1.0-rc2
+  containerdVersion: 1.6.8
+  nerdctlVersion: 0.22.2
   part: 1
   criType: containerd
 jobs:

--- a/.github/workflows/autobuild-k8s-part1.yml
+++ b/.github/workflows/autobuild-k8s-part1.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
 
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
@@ -91,8 +89,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-k8s-part2.yml
+++ b/.github/workflows/autobuild-k8s-part2.yml
@@ -8,6 +8,7 @@ env:
   containerdVersion: 1.6.2
   nerdctlVersion: 0.16.0
   part: 2
+  criType: containerd
 jobs:
   resolve-versions-arch:
     if: startswith(github.event.comment.body, '/imagebuild_k8s')

--- a/.github/workflows/autobuild-k8s-part2.yml
+++ b/.github/workflows/autobuild-k8s-part2.yml
@@ -4,9 +4,9 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
-  containerdVersion: 1.6.2
-  nerdctlVersion: 0.16.0
+  sealos: 4.1.0-rc2
+  containerdVersion: 1.6.8
+  nerdctlVersion: 0.22.2
   part: 2
   criType: containerd
 jobs:

--- a/.github/workflows/autobuild-k8s-part2.yml
+++ b/.github/workflows/autobuild-k8s-part2.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
 
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
@@ -91,8 +89,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image

--- a/.github/workflows/autobuild-k8s-part3.yml
+++ b/.github/workflows/autobuild-k8s-part3.yml
@@ -4,9 +4,9 @@ on:
     types:
       - created
 env:
-  sealos: 4.1.0-rc1
-  containerdVersion: 1.6.2
-  nerdctlVersion: 0.16.0
+  sealos: 4.1.0-rc2
+  containerdVersion: 1.6.8
+  nerdctlVersion: 0.22.2
   part: 3
   criType: containerd
 jobs:

--- a/.github/workflows/autobuild-k8s-part3.yml
+++ b/.github/workflows/autobuild-k8s-part3.yml
@@ -8,6 +8,7 @@ env:
   containerdVersion: 1.6.2
   nerdctlVersion: 0.16.0
   part: 3
+  criType: containerd
 jobs:
   resolve-versions-arch:
     if: startswith(github.event.comment.body, '/imagebuild_k8s')

--- a/.github/workflows/autobuild-k8s-part3.yml
+++ b/.github/workflows/autobuild-k8s-part3.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
 
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
@@ -91,8 +89,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.TOKEN }}
       - name: Download buildah and sealos
         run: .github/scripts/download.sh
       - name: Manifest Image


### PR DESCRIPTION
Bug
===
- Fix autobuild-k8s criType

Feature
===

- Get version files dynamically

Other
===
- remove redundant env for actions/checkout

Update
===
- `sealos`: [v4.1.0-rc2](https://github.com/labring/sealos/releases/tag/v4.1.0-rc2)
- containerd: 1.6.8
- docker: 20.10.17
- nerdctl: 0.22.2