### PR TITLE
fix trivy-operator

### DIFF
--- a/applications/trivy-operator/latest/init.sh
+++ b/applications/trivy-operator/latest/init.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+
+export readonly ARCH=${1:-amd64}
+export readonly NAME=${2:-$(basename "${PWD%/*}")}
+export readonly VERSION=${3:-$(basename "$PWD")}
+
+rm -rf charts/ images/shim/
+mkdir -p charts/ images/shim/
+
+# Remove `v` from image tag `vx.x.x`
+chart_version=`echo ${VERSION} | sed 's/.//'`
+
+helm repo add aqua https://aquasecurity.github.io/helm-charts/
+helm pull aqua/trivy-operator --version=${chart_version} -d charts/ --untar
+
+# Parse trivy image tag
+trivy_tag=`helm show values charts/trivy-operator --jsonpath '{.trivy.tag}'`
+echo "ghcr.io/aquasecurity/trivy:$trivy_tag" > images/shim/trivyImages
+
+cat <<EOF >"Kubefile"
+FROM scratch
+COPY charts charts
+COPY registry registry
+CMD ["helm upgrade -i trivy-operator charts/trivy-operator -n trivy-system --create-namespace --set trivy.ignoreUnfixed=true"]
+EOF

--- a/applications/trivy-operator/v0.5.0/Kubefile
+++ b/applications/trivy-operator/v0.5.0/Kubefile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY charts charts
+COPY registry registry
+CMD ["helm upgrade -i trivy-operator charts/trivy-operator -n trivy-system --create-namespace --set trivy.ignoreUnfixed=true"]

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/.helmignore
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/Chart.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: 0.5.0
+description: Keeps security report resources updated
+keywords:
+- aquasecurity
+- trivyoperator
+- trivy
+name: trivy-operator
+sources:
+- https://github.com/aquasecurity/trivy-operator
+type: application
+version: 0.5.0

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_clusterconfigauditreports.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_clusterconfigauditreports.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: clusterconfigauditreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: ClusterConfigAuditReport
+    listKind: ClusterConfigAuditReportList
+    plural: clusterconfigauditreports
+    shortNames:
+    - clusterconfigaudit
+    singular: clusterconfigauditreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of the config audit scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterConfigAuditReport is a specification for the ClusterConfigAuditReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: ConfigAuditSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            type: object
+        required:
+        - report
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_clusterrbacassessmentreports.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_clusterrbacassessmentreports.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: clusterrbacassessmentreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: ClusterRbacAssessmentReport
+    listKind: ClusterRbacAssessmentReportList
+    plural: clusterrbacassessmentreports
+    shortNames:
+    - clusterrbacassessmentreport
+    singular: clusterrbacassessmentreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of the rbac assessment scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterRbacAssessmentReport is a specification for the ClusterRbacAssessmentReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: RbacAssessmentSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+            required:
+            - checks
+            - scanner
+            - summary
+            type: object
+        required:
+        - report
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_configauditreports.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_configauditreports.yaml
@@ -1,0 +1,174 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: configauditreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: ConfigAuditReport
+    listKind: ConfigAuditReportList
+    plural: configauditreports
+    shortNames:
+    - configaudit
+    - configaudits
+    singular: configauditreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of the config audit scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ConfigAuditReport is a specification for the ConfigAuditReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: ConfigAuditSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                format: date-time
+                type: string
+            required:
+            - checks
+            type: object
+        required:
+        - report
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_exposedsecretreports.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_exposedsecretreports.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: exposedsecretreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: ExposedSecretReport
+    listKind: ExposedSecretReportList
+    plural: exposedsecretreports
+    shortNames:
+    - exposedsecret
+    - exposedsecrets
+    singular: exposedsecretreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the exposed secret scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical exposed secrets
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high exposed secrets
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium exposed secrets
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low exposed secrets
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ExposedSecretReport summarizes exposed secrets in plaintext files
+          built into container images.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            description: Report is the actual exposed secret report data.
+            properties:
+              artifact:
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
+                properties:
+                  digest:
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
+                    type: string
+                  mimeType:
+                    description: MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
+                    type: string
+                  tag:
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
+                    type: string
+                type: object
+              registry:
+                description: Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              secrets:
+                description: Exposed secrets is a list of passwords, api keys, tokens
+                  and others items found in the Artifact.
+                items:
+                  description: ExposedSecret is the spec for a exposed secret record.
+                  properties:
+                    category:
+                      type: string
+                    match:
+                      description: Match where the exposed rule matched.
+                      type: string
+                    ruleID:
+                      description: RuleID is rule the identifier.
+                      type: string
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      type: string
+                    target:
+                      description: Target is where the exposed secret was found.
+                      type: string
+                    title:
+                      type: string
+                  required:
+                  - category
+                  - match
+                  - ruleID
+                  - severity
+                  - target
+                  - title
+                  type: object
+                type: array
+              summary:
+                description: Summary is the exposed secrets counts grouped by Severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of exposed secrets with
+                      Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of exposed secrets with High
+                      Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of exposed secrets with Low
+                      Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of exposed secrets with
+                      Medium Severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+              updateTimestamp:
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
+                format: date-time
+                type: string
+            required:
+            - artifact
+            - scanner
+            - secrets
+            - summary
+            - updateTimestamp
+            type: object
+        required:
+        - report
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_rbacassessmentreports.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_rbacassessmentreports.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: rbacassessmentreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: RbacAssessmentReport
+    listKind: RbacAssessmentReportList
+    plural: rbacassessmentreports
+    shortNames:
+    - rbacassessment
+    - rbacassessments
+    singular: rbacassessmentreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of the rbac assessment scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of failed checks with critical severity
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of failed checks with high severity
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of failed checks with medium severity
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of failed checks with low severity
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RbacAssessmentReport is a specification for the RbacAssessmentReport
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            properties:
+              checks:
+                description: Checks provides results of conducting audit steps.
+                items:
+                  description: Check provides the result of conducting a single audit
+                    step.
+                  properties:
+                    category:
+                      type: string
+                    checkID:
+                      type: string
+                    description:
+                      type: string
+                    messages:
+                      items:
+                        type: string
+                      type: array
+                    remediation:
+                      description: Remediation provides description or links to external
+                        resources to remediate failing check.
+                      type: string
+                    scope:
+                      description: Scope indicates the section of config that was
+                        audited.
+                      properties:
+                        type:
+                          description: Type indicates type of this scope, e.g. Container,
+                            ConfigMapKey or JSONPath.
+                          type: string
+                        value:
+                          description: Value indicates value of this scope that depends
+                            on Type, e.g. container name, ConfigMap key or JSONPath
+                            expression
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      type: string
+                    success:
+                      type: boolean
+                    title:
+                      type: string
+                  required:
+                  - checkID
+                  - severity
+                  - success
+                  type: object
+                type: array
+              scanner:
+                description: Scanner is the spec for a scanner generating a security
+                  assessment report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: RbacAssessmentSummary counts failed checks by severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of failed checks with
+                      critical severity.
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of failed checks with high
+                      severity.
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of failed check with low severity.
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of failed checks with medium
+                      severity.
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                type: object
+            required:
+            - checks
+            - scanner
+            - summary
+            type: object
+        required:
+        - report
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/crds/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -1,0 +1,256 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: vulnerabilityreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: VulnerabilityReport
+    listKind: VulnerabilityReportList
+    plural: vulnerabilityreports
+    shortNames:
+    - vuln
+    - vulns
+    singular: vulnerabilityreport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the vulnerability scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical vulnerabilities
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high vulnerabilities
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium vulnerabilities
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low vulnerabilities
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    - description: The number of unknown vulnerabilities
+      jsonPath: .report.summary.unknownCount
+      name: Unknown
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VulnerabilityReport summarizes vulnerabilities in application
+          dependencies and operating system packages built into container images.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            description: Report is the actual vulnerability report data.
+            properties:
+              artifact:
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
+                properties:
+                  digest:
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
+                    type: string
+                  mimeType:
+                    description: MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
+                    type: string
+                  tag:
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
+                    type: string
+                type: object
+              registry:
+                description: Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: Summary is a summary of Vulnerability counts grouped
+                  by Severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of vulnerabilities with
+                      Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of vulnerabilities with High
+                      Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of vulnerabilities with Low
+                      Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of vulnerabilities with
+                      Medium Severity.
+                    minimum: 0
+                    type: integer
+                  noneCount:
+                    description: NoneCount is the number of packages without any vulnerability.
+                    minimum: 0
+                    type: integer
+                  unknownCount:
+                    description: UnknownCount is the number of vulnerabilities with
+                      unknown severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                - unknownCount
+                type: object
+              updateTimestamp:
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
+                format: date-time
+                type: string
+              vulnerabilities:
+                description: Vulnerabilities is a list of operating system (OS) or
+                  application software Vulnerability items found in the Artifact.
+                items:
+                  description: Vulnerability is the spec for a vulnerability record.
+                  properties:
+                    class:
+                      type: string
+                    cvss:
+                      additionalProperties:
+                        properties:
+                          V2Score:
+                            type: number
+                          V2Vector:
+                            type: string
+                          V3Score:
+                            type: number
+                          V3Vector:
+                            type: string
+                        type: object
+                      type: object
+                    cvsssource:
+                      type: string
+                    description:
+                      type: string
+                    fixedVersion:
+                      description: FixedVersion indicates the version of the Resource
+                        in which this vulnerability has been fixed.
+                      type: string
+                    installedVersion:
+                      description: InstalledVersion indicates the installed version
+                        of the Resource.
+                      type: string
+                    links:
+                      items:
+                        type: string
+                      type: array
+                    primaryLink:
+                      type: string
+                    resource:
+                      description: Resource is a vulnerable package, application,
+                        or library.
+                      type: string
+                    score:
+                      type: number
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      - UNKNOWN
+                      type: string
+                    target:
+                      type: string
+                    title:
+                      type: string
+                    vulnerabilityID:
+                      description: VulnerabilityID the vulnerability identifier.
+                      type: string
+                  required:
+                  - fixedVersion
+                  - installedVersion
+                  - resource
+                  - severity
+                  - title
+                  - vulnerabilityID
+                  type: object
+                type: array
+            required:
+            - artifact
+            - scanner
+            - summary
+            - updateTimestamp
+            - vulnerabilities
+            type: object
+        required:
+        - report
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/generated/role.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/generated/role.yaml
@@ -1,0 +1,272 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: trivy-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancedetailreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancereports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancereports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clusterconfigauditreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clusterrbacassessmentreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - configauditreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - exposedsecretreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - rbacassessmentreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - vulnerabilityreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - watch

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/NOTES.txt
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/NOTES.txt
@@ -1,0 +1,15 @@
+You have installed Trivy Operator in the {{ include "trivy-operator.namespace" . }} namespace.
+It is configured to discover Kubernetes workloads and resources in
+{{ tpl .Values.targetNamespaces . | default "all" }} namespace(s).
+
+Inspect created VulnerabilityReports by:
+
+    kubectl get vulnerabilityreports --all-namespaces -o wide
+
+Inspect created ConfigAuditReports by:
+
+    kubectl get configauditreports --all-namespaces -o wide
+
+Inspect the work log of trivy-operator by:
+
+    kubectl logs -n {{ include "trivy-operator.namespace" . }} deployment/{{ include "trivy-operator.fullname" . }}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/_helpers.tpl
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trivy-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec). If release name contains chart name it will be used
+as a full name.
+*/}}
+{{- define "trivy-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trivy-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "trivy-operator.labels" -}}
+{{- if eq .Values.managedBy "Helm" -}}
+helm.sh/chart: {{ include "trivy-operator.chart" . }}
+{{ end -}}
+{{ include "trivy-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Values.managedBy }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "trivy-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trivy-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "trivy-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "trivy-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "trivy-operator.namespace" -}}
+{{- default .Release.Namespace .Values.operator.namespace }}
+{{- end }}
+

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/config.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/config.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+  {{- with .Values.trivyOperator.scanJobTolerations }}
+  scanJob.tolerations: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobAnnotations }}
+  scanJob.annotations: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobAutomountServiceAccountToken }}
+  scanJob.automountServiceAccountToken: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobPodTemplateLabels }}
+  scanJob.podTemplateLabels: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobNodeSelector }}
+  scanJob.nodeSelector: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobPodTemplatePodSecurityContext }}
+  scanJob.podTemplatePodSecurityContext: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobPodTemplateContainerSecurityContext }}
+  scanJob.podTemplateContainerSecurityContext: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobCompressLogs }}
+  scanJob.compressLogs: {{ . | toJson | quote }}
+  {{- end }}
+  {{- if .Values.operator.vulnerabilityScannerEnabled }}
+  vulnerabilityReports.scanner: {{ .Values.trivyOperator.vulnerabilityReportsPlugin | quote }}
+  {{- end }}
+  {{- if .Values.operator.configAuditScannerEnabled }}
+  configAuditReports.scanner: {{ .Values.trivyOperator.configAuditReportsPlugin | quote }}
+  {{- end }}
+  {{- if .Values.operator.clusterComplianceEnabled }}
+  compliance.failEntriesLimit: {{ required ".Values.compliance.failEntriesLimit is required" .Values.compliance.failEntriesLimit | quote }}
+  {{- end }}
+  {{- if .Values.trivyOperator.reportResourceLabels }}
+  report.resourceLabels: {{ .Values.trivyOperator.reportResourceLabels | quote }}
+  metrics.resourceLabelsPrefix: {{ .Values.trivyOperator.metricsResourceLabelsPrefix | quote }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trivy-operator
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+{{- if eq .Values.trivyOperator.vulnerabilityReportsPlugin "Trivy" }}
+{{- with .Values.trivy }}
+{{- if .createConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator-trivy-config
+  namespace: {{ include "trivy-operator.namespace" $ }}
+  labels:
+    {{- include "trivy-operator.labels" $ | nindent 4 }}
+data:
+  trivy.repository: {{ required ".Values.trivy.repository is required" .repository | quote }}
+  trivy.tag: {{ required ".Values.trivy.tag is required" .tag | quote }}
+  trivy.mode: {{ .mode | quote }}
+  trivy.additionalVulnerabilityReportFields: {{ .additionalVulnerabilityReportFields | quote}}
+  {{- if .httpProxy }}
+  trivy.httpProxy: {{ .httpProxy | quote }}
+  {{- end }}
+  {{- if .httpsProxy }}
+  trivy.httpsProxy: {{ .httpsProxy | quote }}
+  {{- end }}
+  {{- if .serverInsecure }}
+  trivy.serverInsecure: {{ .serverInsecure | quote }}
+  {{- end }}
+  {{- if .noProxy }}
+  trivy.noProxy: {{ .noProxy | quote }}
+  {{- end }}
+  {{- range $key, $registry := .nonSslRegistries }}
+  trivy.nonSslRegistry.{{ $key }}: {{ $registry | quote }}
+  {{- end }}
+  {{- range $key, $registry := .insecureRegistries }}
+  trivy.insecureRegistry.{{ $key }}: {{ $registry | quote }}
+  {{- end }}
+  {{- range $key, $registry := .registry.mirror }}
+  trivy.registry.mirror.{{ $key }}: {{ $registry | quote }}
+  {{- end }}
+  trivy.severity: {{ .severity | quote }}
+  trivy.dbRepository: {{ .dbRepository | quote }}
+  trivy.command: {{ .command | quote }}
+  {{- if .dbRepositoryInsecure }}
+  trivy.dbRepositoryInsecure: {{ .dbRepositoryInsecure | quote }}
+  {{- end }}
+  {{- if .useBuiltinRegoPolicies }}
+  trivy.useBuiltinRegoPolicies: {{ .useBuiltinRegoPolicies | quote }}
+  {{- end }}
+  trivy.supportedConfigAuditKinds: {{ .supportedConfigAuditKinds | quote }}
+  {{- if .ignoreUnfixed }}
+  trivy.ignoreUnfixed: {{ .ignoreUnfixed | quote }}
+  {{- end }}
+  {{- if .timeout }}
+  trivy.timeout: {{ .timeout | quote }}
+  {{- end }}
+  {{- with .ignoreFile }}
+  trivy.ignoreFile: |
+{{- . | trim | nindent 4 }}
+  {{- end }}
+  {{- if eq .mode "ClientServer" }}
+  trivy.serverURL: {{ required ".Values.trivy.serverURL is required" .serverURL | quote }}
+  {{- end }}
+  {{- with .resources }}
+    {{- with .requests }}
+      {{- if .cpu }}
+  trivy.resources.requests.cpu: {{ .cpu }}
+      {{- end }}
+      {{- if hasKey . "memory" }}
+  trivy.resources.requests.memory: {{ .memory }}
+      {{- end }}
+    {{- end }}
+    {{- with .limits }}
+      {{- if .cpu }}
+  trivy.resources.limits.cpu: {{ .cpu }}
+      {{- end }}
+      {{- if .memory }}
+  trivy.resources.limits.memory: {{ .memory }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trivy-operator-trivy-config
+  namespace: {{ include "trivy-operator.namespace" $ }}
+  labels:
+    {{- include "trivy-operator.labels" $ | nindent 4 }}
+data:
+  {{- if .githubToken }}
+  trivy.githubToken: {{ .githubToken | b64enc | quote }}
+  {{- end }}
+  {{- if eq .mode "ClientServer" }}
+  {{- if .serverToken }}
+  trivy.serverToken: {{ .serverToken | b64enc | quote }}
+  {{- end }}
+  {{- if .serverCustomHeaders }}
+  trivy.serverCustomHeaders: {{ .serverCustomHeaders | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/deployment.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.operator.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "trivy-operator.selectorLabels" . | nindent 8 }}
+        {{- if .Values.operator.podLabels }}
+        {{- toYaml .Values.operator.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "trivy-operator.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      containers:
+        - name: {{ .Chart.Name | quote }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- with .Values.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          env:
+            - name: OPERATOR_NAMESPACE
+              value: {{ include "trivy-operator.namespace" . }}
+            - name: OPERATOR_TARGET_NAMESPACES
+              value: {{ .Values.targetNamespaces | quote }}
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: {{ printf "%s,%s" (tpl .Values.excludeNamespaces .) (include "trivy-operator.namespace" . ) | quote }}
+            - name: OPERATOR_TARGET_WORKLOADS
+              value: {{ tpl .Values.targetWorkloads . | quote }}
+            - name: OPERATOR_SERVICE_ACCOUNT
+              value: {{ include "trivy-operator.serviceAccountName" . | quote }}
+            - name: OPERATOR_LOG_DEV_MODE
+              value: {{ .Values.operator.logDevMode | quote }}
+            - name: OPERATOR_SCAN_JOB_TIMEOUT
+              value: {{ .Values.operator.scanJobTimeout | quote }}
+            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
+              value: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
+            - name: OPERATOR_SCAN_JOB_RETRY_AFTER
+              value: {{ .Values.operator.scanJobsRetryDelay | quote }}
+            - name: OPERATOR_BATCH_DELETE_LIMIT
+              value: {{ .Values.operator.batchDeleteLimit | quote }}
+            - name: OPERATOR_BATCH_DELETE_DELAY
+              value: {{ .Values.operator.batchDeleteDelay | quote }}
+            - name: OPERATOR_METRICS_BIND_ADDRESS
+              value: ":8080"
+            - name: OPERATOR_METRICS_FINDINGS_ENABLED
+              value: {{ .Values.operator.metricsFindingsEnabled | quote }}
+            - name: OPERATOR_METRICS_VULN_ID_ENABLED
+              value: {{ .Values.operator.metricsVulnIdEnabled | quote }}
+            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
+              value: ":9090"
+            - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
+              value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
+            - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
+              value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
+            - name: OPERATOR_SCANNER_REPORT_TTL
+              value: {{ .Values.operator.scannerReportTTL | quote }}
+            - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
+              value: {{ .Values.operator.configAuditScannerEnabled | quote }}
+            - name: OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED
+              value: {{ .Values.operator.rbacAssessmentScannerEnabled | quote }}
+            - name: OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
+              value: {{ .Values.operator.configAuditScannerScanOnlyCurrentRevisions | quote }}
+            - name: OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED
+              value: {{ .Values.operator.exposedSecretScannerEnabled | quote }}
+            - name: OPERATOR_WEBHOOK_BROADCAST_URL
+              value: {{ .Values.operator.webhookBroadcastURL | quote }}
+            - name: OPERATOR_WEBHOOK_BROADCAST_TIMEOUT
+              value: {{ .Values.operator.webhookBroadcastTimeout | quote }}
+            - name: OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES
+              value: {{ .Values.operator.privateRegistryScanSecretsNames | toJson | quote }}
+            - name: OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS
+              value: {{ .Values.operator.accessGlobalSecretsAndServiceAccount | quote }}
+            {{- if gt (int .Values.operator.replicas) 1 }}
+            - name: OPERATOR_LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: OPERATOR_LEADER_ELECTION_ID
+              value: {{ .Values.operator.leaderElectionId | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: probes
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          resources:
+            {{- .Values.resources | toYaml | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/leader_election.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/leader_election.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.rbac.create}}
+---
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-leader-election
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}-leader-election
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trivy-operator.fullname" . }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "trivy-operator.serviceAccountName" . }}
+    namespace: {{ include "trivy-operator.namespace" . }}
+{{- end}}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/ns.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/ns.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.operator.namespace }}
+{{- if not (lookup "v1" "Namespace" "" .Values.operator.namespace) }}
+{{- if not (eq .Release.Namespace .Values.operator.namespace) }}
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.operator.namespace }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+
+{{- end }}
+{{- end }}
+{{- end }}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/policies.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/policies.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator-policies-config
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+# example
+# policy.my_policy.kinds: Workload
+# policy.my_policy.rego: "package builtin.kubernetes.KSV008
+#
+# import data.lib.kubernetes
+# import data.lib.result
+#
+# default failHostIPC = false
+#
+# __rego_metadata__ := {
+#	 "id": "KSV008",
+#	 "avd_id": "AVD-KSV-0008",
+#	 "title": "Access to host IPC namespace",
+#	 "short_code": "no-shared-ipc-namespace",
+#	 "version": "v1.0.0",
+#	 "severity": "HIGH",
+#	 "type": "Kubernetes Security Check",
+#	 "description": "Sharing the host’s IPC namespace allows container processes to communicate with processes on the host.",
+#	 "recommended_actions": "Do not set 'spec.template.spec.hostIPC' to true.",
+#	 "url": "https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline",
+#}
+#
+# __rego_input__ := {
+#	 "combine": false,
+#	 "selector": [{"type": "kubernetes"}],
+# }
+#
+## failHostIPC is true if spec.hostIPC is set to true (on all resources)
+# failHostIPC {
+#	 kubernetes.host_ipcs[_] == true
+# }
+#
+#deny[res] {
+#	failHostIPC
+#	msg := kubernetes.format(sprintf("%s '%s' should not set 'spec.template.spec.hostIPC' to true", [kubernetes.kind, kubernetes.name]))
+#	res := result.new(msg, input.spec)
+#}"

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/rbac.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/rbac.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "trivy-operator.serviceAccountName" . }}
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.rbac.create }}
+{{ .Files.Get "generated/role.yaml" }}
+
+{{- if .Values.operator.accessGlobalSecretsAndServiceAccount -}}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "trivy-operator.serviceAccountName" . }}
+    namespace: {{ include "trivy-operator.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trivy-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "trivy-operator.serviceAccountName" . }}
+    namespace: {{ include "trivy-operator.namespace" . }}
+{{- end }}
+
+---
+# permissions for end users to view configauditreports
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-config-audit-reports-view
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - configauditreports
+    verbs:
+      - get
+      - list
+      - watch
+---
+# permissions for end users to view exposedsecretreports
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-exposed-secret-reports-view
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - exposedsecretreports
+    verbs:
+      - get
+      - list
+      - watch
+---
+# permissions for end users to view vulnerabilityreports
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-vulnerability-reports-view
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - vulnerabilityreports
+    verbs:
+      - get
+      - list
+      - watch

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/service.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "trivy-operator.selectorLabels" . | nindent 4 }}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/servicemonitor.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.serviceMonitor.enabled true }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "trivy-operator.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "trivy-operator.namespace" . ) }}
+  labels:
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.serviceMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+    - {{ include "trivy-operator.namespace" . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "trivy-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - honorLabels: {{ .Values.serviceMonitor.honorLabels | default true }}
+    port: metrics
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    scheme: http
+{{- end }}

--- a/applications/trivy-operator/v0.5.0/charts/trivy-operator/values.yaml
+++ b/applications/trivy-operator/v0.5.0/charts/trivy-operator/values.yaml
@@ -1,0 +1,342 @@
+# Default values for the trivy-operator Helm chart, these are used to render
+# the templates into valid k8s Resources.
+
+# managedBy is similar to .Release.Service but allows to overwrite the value
+managedBy: Helm
+
+# targetNamespace defines where you want trivy-operator to operate. By
+# default, it's a blank string to select all namespaces, but you can specify
+# another namespace, or a comma separated list of namespaces.
+targetNamespaces: ""
+
+# excludeNamespaces is a comma separated list of namespaces (or glob patterns)
+# to be excluded from scanning. Only applicable in the all namespaces install
+# mode, i.e. when the targetNamespaces values is a blank string.
+excludeNamespaces: "kube-system"
+
+# targetWorkloads is a comma seperated list of Kubernetes workload resources
+# to be included in the vulnerability and config-audit scans
+# if left blank, all workload resources will be scanned
+targetWorkloads: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
+
+nameOverride: ""
+fullnameOverride: ""
+
+operator:
+  # namespace to install the operator, defaults to the .Release.Namespace
+  namespace: ""
+  # replicas the number of replicas of the operator's pod
+  replicas: 1
+
+  # additional labels for the operator pod
+  podLabels: {}
+
+  # leaderElectionId determines the name of the resource that leader election
+  # will use for holding the leader lock.
+  leaderElectionId: "trivyoperator-lock"
+
+  # logDevMode the flag to enable development mode (more human-readable output, extra stack traces and logging information, etc)
+  logDevMode: false
+
+  # scanJobTimeout the length of time to wait before giving up on a scan job
+  scanJobTimeout: 5m
+
+  # scanJobsConcurrentLimit the maximum number of scan jobs create by the operator
+  scanJobsConcurrentLimit: 10
+
+  # scanJobsRetryDelay the duration to wait before retrying a failed scan job
+  scanJobsRetryDelay: 30s
+
+  # vulnerabilityScannerEnabled the flag to enable vulnerability scanner
+  vulnerabilityScannerEnabled: true
+  # scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled
+  scannerReportTTL: "24h"
+  # configAuditScannerEnabled the flag to enable configuration audit scanner
+  configAuditScannerEnabled: true
+  # rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner
+  rbacAssessmentScannerEnabled: true
+  # batchDeleteLimit the maximum number of config audit reports deleted by the operator when the plugin's config has changed.
+  batchDeleteLimit: 10
+  # vulnerabilityScannerScanOnlyCurrentRevisions the flag to only create vulnerability scans on the current revision of a deployment.
+  vulnerabilityScannerScanOnlyCurrentRevisions: true
+  # configAuditScannerScanOnlyCurrentRevisions the flag to only create config audit scans on the current revision of a deployment.
+  configAuditScannerScanOnlyCurrentRevisions: true
+  # batchDeleteDelay the duration to wait before deleting another batch of config audit reports.
+  batchDeleteDelay: 10s
+  # accessGlobalSecretsAndServiceAccount The flag to enable access to global secrets/service accounts to allow `vulnerability scan job` to pull images from private registries
+  accessGlobalSecretsAndServiceAccount: true
+
+  # metricsFindingsEnabled the flag to enable metrics for findings
+  metricsFindingsEnabled: true
+
+  # metricsVulnIdEnabled the flag to enable metrics about cve vulns id
+  # be aware of metrics cardinality is significantly increased with this feature enabled.
+  metricsVulnIdEnabled: false
+
+  # exposedSecretScannerEnabled the flag to enable exposed secret scanner
+  exposedSecretScannerEnabled: true
+
+  # webhookBroadcastURL the flag to set reports should be sent to a webhook endpoint. "" means that the webhookBroadcastURL feature is disabled
+  webhookBroadcastURL: ""
+
+  # webhookBroadcastTimeout the flag to set timeout for webhook requests if webhookBroadcastURL is enabled
+  webhookBroadcastTimeout: 30s
+
+  # privateRegistryScanSecretsNames is map of namespace:secrets which can be used to authenticate in private registries in case if there no imagePullSecrets provided
+  privateRegistryScanSecretsNames: {}
+
+image:
+  repository: "ghcr.io/aquasecurity/trivy-operator"
+  # tag is an override of the image tag, which is by default set by the
+  # appVersion field in Chart.yaml.
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# service only expose a metrics endpoint for prometheus to scrape,
+# trivy-operator does not have a user interface.
+service:
+  metricsPort: 80
+
+# Prometheus ServiceMonitor configuration
+serviceMonitor:
+  # enabled determines whether a serviceMonitor should be deployed
+  enabled: false
+  # The namespace where Prometheus expects to find service monitors
+  # namespace: ""
+  interval: ""
+  # Additional labels for the serviceMonitor
+  labels: {}
+  # honorLabels: true
+
+trivyOperator:
+  # vulnerabilityReportsPlugin the name of the plugin that generates vulnerability reports `Trivy`
+  vulnerabilityReportsPlugin: "Trivy"
+  # configAuditReportsPlugin the name of the plugin that generates config audit reports.
+  configAuditReportsPlugin: "Trivy"
+  # scanJobCompressLogs control whether scanjob output should be compressed or plain
+  scanJobCompressLogs: true
+  # scanJobTolerations tolerations to be applied to the scanner pods so that they can run on nodes with matching taints
+  scanJobTolerations: []
+  # If you do want to specify tolerations, uncomment the following lines, adjust them as necessary, and remove the
+  # square brackets after 'scanJobTolerations:'.
+  # - key: "key1"
+  #   operator: "Equal"
+  #   value: "value1"
+  #   effect: "NoSchedule"
+
+  # scanJobNodeSelector nodeSelector to be applied to the scanner pods so that they can run on nodes with matching labels
+  scanJobNodeSelector: {}
+  # If you do want to specify nodeSelector, uncomment the following lines, adjust them as necessary, and remove the
+  # square brackets after 'scanJobNodeSelector:'.
+  #   nodeType: worker
+  #   cpu: sandylake
+  #   teamOwner: operators
+
+  # scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job
+  scanJobAutomountServiceAccountToken: false
+
+  # scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner pods to be
+  # annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage`
+  scanJobAnnotations: ""
+
+  # scanJobPodTemplateLabels comma-separated representation of the labels which the user wants the scanner pods to be
+  # labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage`
+  scanJobPodTemplateLabels: ""
+
+  # scanJobPodTemplatePodSecurityContext podSecurityContext the user wants the scanner pods to be amended with.
+  # Example:
+  #   RunAsUser: 10000
+  #   RunAsGroup: 10000
+  #   RunAsNonRoot: true
+  scanJobPodTemplatePodSecurityContext: {}
+
+  # scanJobPodTemplateContainerSecurityContext SecurityContext the user wants the scanner containers (and their
+  # initContainers) to be amended with.
+  scanJobPodTemplateContainerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    # For filesystem scanning, Trivy needs to run as the root user
+    # runAsUser: 0
+
+  # reportResourceLabels comma-separated scanned resource labels which the user wants to include in the Prometheus
+  # metrics report. Example: `owner,app`
+  reportResourceLabels: ""
+
+  # metricsResourceLabelsPrefix Prefix that will be prepended to the labels names indicated in `reportResourceLabels`
+  # when including them in the Prometheus metrics
+  metricsResourceLabelsPrefix: "k8s_label_"
+
+trivy:
+  # createConfig indicates whether to create config objects
+  createConfig: true
+
+  # repository of the Trivy image
+  repository: ghcr.io/aquasecurity/trivy
+  # tag version of the Trivy image
+  tag: 0.31.3
+
+  # mode is the Trivy client mode. Either Standalone or ClientServer. Depending
+  # on the active mode other settings might be applicable or required.
+  mode: Standalone
+
+  # additionalVulnerabilityReportFields is a comma separated list of additional fields which
+  # can be added to the VulnerabilityReport. Supported parameters: Description, Links, CVSS, Target and Class
+  additionalVulnerabilityReportFields: ""
+
+  # httpProxy is the HTTP proxy used by Trivy to download the vulnerabilities database from GitHub.
+  #
+  # httpProxy:
+
+  # httpsProxy is the HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub.
+  #
+  # httpsProxy:
+
+  # noProxy is a comma separated list of IPs and domain names that are not subject to proxy settings.
+  #
+  # noProxy:
+
+  # Registries without SSL. There can be multiple registries with different keys.
+  nonSslRegistries: {}
+  #  pocRegistry: poc.myregistry.harbor.com.pl
+  #  qaRegistry: qa.registry.aquasec.com
+  #  internalRegistry: registry.registry.svc:5000
+
+  # The registry to which insecure connections are allowed. There can be multiple registries with different keys.
+  insecureRegistries: {}
+  #  pocRegistry: poc.myregistry.harbor.com.pl
+  #  qaRegistry: qa.registry.aquasec.com
+  #  internalRegistry: registry.registry.svc:5000
+
+  # Mirrored registries. There can be multiple registries with different keys.
+  # Make sure to quote registries containing dots
+  registry:
+    mirror: {}
+    # "docker.io": docker-mirror.example.com
+
+  # severity is a comma separated list of severity levels reported by Trivy.
+  severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+
+  # ignoreUnfixed is the flag to show only fixed vulnerabilities in
+  # vulnerabilities reported by Trivy. Set to true to enable it.
+  #
+  ignoreUnfixed: false
+
+  # timeout is the duration to wait for scan completion.
+  timeout: "5m0s"
+
+  # ignoreFile can be used to tell Trivy to ignore vulnerabilities by ID (one per line)
+  #
+  # ignoreFile: |
+  #   CVE-1970-0001
+  #   CVE-1970-0002
+
+  # resources resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100M
+    limits:
+      cpu: 500m
+      memory: 500M
+
+  # githubToken is the GitHub access token used by Trivy to download the vulnerabilities
+  # database from GitHub. Only applicable in Standalone mode.
+  #
+  # githubToken: "*****"
+
+  # serverURL is the endpoint URL of the Trivy server. Required in ClientServer mode.
+  #
+  # serverURL: "https://trivy.trivy:4975"
+
+  # serverInsecure is the flag to enable insecure connection to the Trivy server.
+  #
+  # serverInsecure: true
+  # serverToken is the token to authenticate Trivy client with Trivy server. Only
+  # applicable in ClientServer mode.
+  #
+  # serverToken: "*****"
+
+  # serverTokenHeader is the name of the HTTP header used to send the authentication
+  # token to Trivy server. Only application in ClientServer mode when
+  # trivy.serverToken is specified.
+  serverTokenHeader: "Trivy-Token"
+
+  # serverCustomHeaders is a comma separated list of custom HTTP headers sent by
+  # Trivy client to Trivy server. Only applicable in ClientServer mode.
+  #
+  # serverCustomHeaders: "foo=bar"
+
+  dbRepository: "ghcr.io/aquasecurity/trivy-db"
+
+  # The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)
+  #
+  dbRepositoryInsecure: "false"
+
+  # The Flag to enable the usage of builtin rego policies by default
+  #
+  useBuiltinRegoPolicies: "true"
+
+  # The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner
+  #
+  supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"
+
+  # command. Either `image` or `filesystem` scanning, depending on the target type required for the scan.
+  # For 'filesystem' scanning, ensure that the `trivyOperator.scanJobPodTemplateContainerSecurityContext` is configured
+  # to run as the root user (runAsUser = 0).
+  command: image
+
+compliance:
+  # failEntriesLimit the flag to limit the number of fail entries per control check in the cluster compliance detail report
+  failEntriesLimit: 10
+
+rbac:
+  create: true
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  annotations: {}
+  # name specifies the name of the k8s Service Account. If not set and create is
+  # true, a name is generated using the fullname template.
+  name: ""
+
+# podAnnotations annotations added to the operator's pod
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+priorityClassName: ""
+
+  # automountServiceAccountToken the flag to enable automount for service account token
+automountServiceAccountToken: true

--- a/applications/trivy-operator/v0.5.0/images/shim/trivyImages
+++ b/applications/trivy-operator/v0.5.0/images/shim/trivyImages
@@ -1,0 +1,1 @@
+ghcr.io/aquasecurity/trivy:0.31.3

--- a/applications/trivy-operator/v0.5.0/init.sh
+++ b/applications/trivy-operator/v0.5.0/init.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+
+export readonly ARCH=${1:-amd64}
+export readonly NAME=${2:-$(basename "${PWD%/*}")}
+export readonly VERSION=${3:-$(basename "$PWD")}
+
+rm -rf charts/ images/shim/
+mkdir -p charts/ images/shim/
+
+# Remove `v` from image tag `vx.x.x`
+chart_version=`echo ${VERSION} | sed 's/.//'`
+
+helm repo add aqua https://aquasecurity.github.io/helm-charts/
+helm pull aqua/trivy-operator --version=${chart_version} -d charts/ --untar
+
+# Parse trivy image tag
+trivy_tag=`helm show values charts/trivy-operator --jsonpath '{.trivy.tag}'`
+echo "ghcr.io/aquasecurity/trivy:$trivy_tag" > images/shim/trivyImages
+
+cat <<EOF >"Kubefile"
+FROM scratch
+COPY charts charts
+COPY registry registry
+CMD ["helm upgrade -i trivy-operator charts/trivy-operator -n trivy-system --create-namespace --set trivy.ignoreUnfixed=true"]
+EOF


### PR DESCRIPTION
Signed-off-by: willzhang <willzhmic@outlook.com>

fix chart version have no `v` in image tag v0.5.0.

this used for chart version defferent from app version.
```
chart_version=`helm search repo --versions --regexp '\vaqua/trivy-operator\v' |grep ${VERSION} | awk '{print $2}' | sort -rn | head -n1`
app_versions=`helm search repo --versions --regexp '\vaqua/trivy-operator\v' | awk '{print $3}' | grep -v VERSION`
```