### PR TITLE
fix: cilium v1.16.0+

### DIFF
--- a/applications/cilium/latest/entrypoint.sh
+++ b/applications/cilium/latest/entrypoint.sh
@@ -5,8 +5,7 @@ cp opt/hubble /usr/bin/
 
 if [ -z "$ExtraValues" ]
 then
-  cilium install --chart-directory charts/cilium --helm-set kubeProxyReplacement=strict,k8sServiceHost=apiserver.cluster.local,k8sServicePort=6443
+  cilium install --chart-directory charts/cilium --helm-set k8sServiceHost=apiserver.cluster.local,k8sServicePort=6443
 else
-  cilium install --chart-directory charts/cilium --helm-set kubeProxyReplacement=strict,k8sServiceHost=apiserver.cluster.local,k8sServicePort=6443,"$ExtraValues"
+  cilium install --chart-directory charts/cilium --helm-set k8sServiceHost=apiserver.cluster.local,k8sServicePort=6443,"$ExtraValues"
 fi
-


### PR DESCRIPTION
- The `strict` option for `kubeProxyReplacement` is deprecated.  (add it using $Extravalues variable.)