### PR TITLE
fix(cert-manager): helm values crds enabeld

### DIFF
--- a/applications/cert-manager/latest/entrypoint.sh
+++ b/applications/cert-manager/latest/entrypoint.sh
@@ -5,7 +5,7 @@ NAME=${NAME:-"cert-manager"}
 NAMESPACE=${NAMESPACE:-"cert-manager"}
 CHARTS=${CHARTS:-"./charts/cert-manager"}
 HELM_OPTS=${HELM_OPTS:-"
---set installCRDs=true \
+--set crds.enabled=true \
 "}
 
 helm upgrade -i ${NAME} ${CHARTS} -n ${NAMESPACE} --create-namespace ${HELM_OPTS} --wait


### PR DESCRIPTION
> https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0

Starting from this version, `installCRDs` has been deprecated.